### PR TITLE
feat(auth): add dual-key rotation with grace period

### DIFF
--- a/scripts/rotate-key.sh
+++ b/scripts/rotate-key.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -e
+
+# Rotate Lambda API key with dual-key grace period.
+#
+# Rotation flow:
+#   1. ./scripts/rotate-key.sh              — generate new key, keep old key valid
+#   2. Update Prose config with new key      — verify it works
+#   3. ./scripts/rotate-key.sh --finalize    — remove old key(s)
+
+cd "$(dirname "$0")/.."
+
+SECRET_ARN="${SECRET_ARN:-$(cd terraform && terraform output -raw api_key_secret_arn 2>/dev/null || true)}"
+
+if [ -z "$SECRET_ARN" ]; then
+  echo "Error: Could not determine secret ARN."
+  echo "Set SECRET_ARN env var or run from project root with terraform outputs."
+  exit 1
+fi
+
+rotate() {
+  echo "Fetching current key(s)..."
+  local current
+  current=$(aws secretsmanager get-secret-value \
+    --secret-id "$SECRET_ARN" \
+    --query SecretString --output text)
+
+  # Generate new key
+  local new_key
+  new_key=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
+
+  # Build dual-key array: [new, ...old]
+  local dual_keys
+  dual_keys=$(echo "$current" | NEW_KEY="$new_key" python3 -c "
+import json, os, sys
+current = sys.stdin.read().strip()
+try:
+    keys = json.loads(current)
+    if not isinstance(keys, list):
+        keys = [current]
+except (json.JSONDecodeError, TypeError):
+    keys = [current]
+print(json.dumps([os.environ['NEW_KEY']] + keys))
+")
+
+  aws secretsmanager put-secret-value \
+    --secret-id "$SECRET_ARN" \
+    --secret-string "$dual_keys" \
+    --output text > /dev/null
+
+  echo ""
+  echo "New key is active. Both old and new keys are now valid."
+  echo ""
+  echo "New API key (copy to Prose config):"
+  echo "  $new_key"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Update Prose with the new key above"
+  echo "  2. Verify Prose works"
+  echo "  3. Run: ./scripts/rotate-key.sh --finalize"
+}
+
+finalize() {
+  echo "Fetching current key(s)..."
+  local current
+  current=$(aws secretsmanager get-secret-value \
+    --secret-id "$SECRET_ARN" \
+    --query SecretString --output text)
+
+  local key_count
+  key_count=$(echo "$current" | python3 -c "
+import json, sys
+current = sys.stdin.read().strip()
+try:
+    keys = json.loads(current)
+    print(len(keys) if isinstance(keys, list) else 1)
+except:
+    print(1)
+")
+
+  if [ "$key_count" -le 1 ]; then
+    echo "Only one key active — nothing to finalize."
+    exit 0
+  fi
+
+  echo "Removing old key(s), keeping only the primary (newest) key..."
+  read -r -p "Confirm? Prose must already be using the new key. [y/N] " confirm
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+
+  local primary_only
+  primary_only=$(echo "$current" | python3 -c "
+import json, sys
+current = sys.stdin.read().strip()
+keys = json.loads(current)
+print(json.dumps([keys[0]] if isinstance(keys, list) else [keys]))
+")
+
+  aws secretsmanager put-secret-value \
+    --secret-id "$SECRET_ARN" \
+    --secret-string "$primary_only" \
+    --output text > /dev/null
+
+  echo "Old key(s) removed. Only the primary key is now valid."
+}
+
+case "${1:-}" in
+  --finalize)
+    finalize
+    ;;
+  --help|-h)
+    echo "Usage: ./scripts/rotate-key.sh [--finalize]"
+    echo ""
+    echo "  (no args)     Generate new key, keep old key valid"
+    echo "  --finalize    Remove old key(s) after verifying Prose works"
+    echo ""
+    echo "Set SECRET_ARN env var or run from project root with terraform outputs."
+    ;;
+  *)
+    rotate
+    ;;
+esac

--- a/src/handler.py
+++ b/src/handler.py
@@ -14,7 +14,7 @@ from typing import Any
 MAX_PAGES = 20
 MAX_PAGE_SIZE = 5 * 1024 * 1024  # 5MB per page
 
-from secrets import get_api_key
+from secrets import get_api_keys
 from rm_renderer import extract_typed_text, render_rm_to_png, has_strokes
 from claude_client import extract_text_from_image
 from markdown_formatter import format_typed_text
@@ -43,15 +43,25 @@ def handler(event: dict, context: Any) -> dict:
     }
     """
     try:
-        # Validate API key
+        # Validate API key against all valid keys (supports dual-key rotation)
         provided_key = (
             event.get("headers", {}).get("x-api-key")
             or event.get("headers", {}).get("X-Api-Key")
         )
-        expected_key = get_api_key()
+        valid_keys = get_api_keys()
 
-        if not provided_key or not compare_digest(provided_key, expected_key):
+        if not provided_key:
             return error_response(401, "Invalid or missing API key")
+
+        key_index = next(
+            (i for i, k in enumerate(valid_keys) if compare_digest(provided_key, k)),
+            -1,
+        )
+        if key_index < 0:
+            return error_response(401, "Invalid or missing API key")
+
+        if key_index > 0:
+            logger.info("Authenticated with grace-period key (rotation pending)")
 
         # Extract user's Anthropic API key
         anthropic_key = (

--- a/src/secrets.py
+++ b/src/secrets.py
@@ -1,10 +1,16 @@
-"""AWS Secrets Manager helper with caching for Lambda container reuse."""
+"""AWS Secrets Manager helper with TTL-based caching for Lambda container reuse."""
 
+import json
 import os
+import time
 import boto3
-from functools import lru_cache
 
 secrets_client = None
+
+# TTL cache state
+_cached_keys: list[str] | None = None
+_cache_time: float = 0
+CACHE_TTL_SECONDS = 300  # 5 minutes — short enough for rotation, low overhead for sporadic traffic
 
 
 def get_secrets_client():
@@ -15,15 +21,27 @@ def get_secrets_client():
     return secrets_client
 
 
-@lru_cache(maxsize=1)
-def get_api_key() -> str:
-    """Get API key from Secrets Manager (cached for Lambda reuse).
+def get_api_keys() -> list[str]:
+    """Get valid API keys from Secrets Manager (cached with TTL).
+
+    Returns a list of valid keys ordered by recency (primary first).
+    During rotation, both old and new keys are valid.
+
+    The secret value can be either:
+    - A JSON array: ["newest-key", "old-key"]
+    - A plain string: "single-key" (backward compatible)
 
     Falls back to API_KEY environment variable for local testing.
     """
+    global _cached_keys, _cache_time
+
     # Check environment variable first (local testing)
     if api_key := os.environ.get("API_KEY"):
-        return api_key
+        return [api_key]
+
+    # Return cached keys if still valid
+    if _cached_keys and (time.monotonic() - _cache_time) < CACHE_TTL_SECONDS:
+        return _cached_keys
 
     # Get from Secrets Manager
     secret_arn = os.environ.get("API_KEY_SECRET_ARN")
@@ -32,4 +50,17 @@ def get_api_key() -> str:
 
     client = get_secrets_client()
     response = client.get_secret_value(SecretId=secret_arn)
-    return response["SecretString"]
+    secret_string = response["SecretString"]
+
+    # Parse as JSON array, fall back to plain string for backward compat
+    try:
+        parsed = json.loads(secret_string)
+        if isinstance(parsed, list):
+            _cached_keys = parsed
+        else:
+            _cached_keys = [secret_string]
+    except (json.JSONDecodeError, TypeError):
+        _cached_keys = [secret_string]
+
+    _cache_time = time.monotonic()
+    return _cached_keys

--- a/src/secrets.py
+++ b/src/secrets.py
@@ -40,7 +40,7 @@ def get_api_keys() -> list[str]:
         return [api_key]
 
     # Return cached keys if still valid
-    if _cached_keys and (time.monotonic() - _cache_time) < CACHE_TTL_SECONDS:
+    if _cached_keys is not None and (time.monotonic() - _cache_time) < CACHE_TTL_SECONDS:
         return _cached_keys
 
     # Get from Secrets Manager
@@ -58,7 +58,7 @@ def get_api_keys() -> list[str]:
         if isinstance(parsed, list):
             _cached_keys = parsed
         else:
-            _cached_keys = [secret_string]
+            _cached_keys = [parsed]
     except (json.JSONDecodeError, TypeError):
         _cached_keys = [secret_string]
 

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -13,6 +13,9 @@ resource "random_password" "api_key" {
 }
 
 # Store the generated API key
+# Note: The rotation script (scripts/rotate-key.sh) transitions this to a
+# JSON array format ["new-key", "old-key"] for dual-key grace periods.
+# The Lambda handles both plain string and JSON array formats.
 resource "aws_secretsmanager_secret_version" "api_key" {
   secret_id     = aws_secretsmanager_secret.api_key.id
   secret_string = random_password.api_key.result

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -29,7 +29,7 @@ def test_error_response_with_code():
 
 def test_missing_api_key():
     """Request without API key returns 401."""
-    with patch("handler.get_api_key", return_value="test-key"):
+    with patch("handler.get_api_keys", return_value=["test-key"]):
         event = {
             "headers": {},
             "requestContext": {"http": {"method": "POST"}},
@@ -40,7 +40,7 @@ def test_missing_api_key():
 
 def test_invalid_api_key():
     """Request with wrong API key returns 401."""
-    with patch("handler.get_api_key", return_value="correct-key"):
+    with patch("handler.get_api_keys", return_value=["correct-key"]):
         event = {
             "headers": {"x-api-key": "wrong-key"},
             "requestContext": {"http": {"method": "POST"}},
@@ -49,9 +49,37 @@ def test_invalid_api_key():
         assert result["statusCode"] == 401
 
 
+def test_grace_period_key_accepted():
+    """During rotation, old (grace-period) key is still accepted."""
+    with patch("handler.get_api_keys", return_value=["new-key", "old-key"]), \
+         patch("handler.process_page", return_value={"id": "t", "markdown": "", "confidence": 1.0}):
+
+        event = {
+            "headers": {"x-api-key": "old-key"},
+            "requestContext": {"http": {"method": "POST"}},
+            "body": json.dumps({"pages": [{"id": "t", "data": base64.b64encode(b"x").decode()}]}),
+        }
+        result = handler(event, None)
+        assert result["statusCode"] == 200
+
+
+def test_primary_key_accepted_during_rotation():
+    """During rotation, new (primary) key is accepted."""
+    with patch("handler.get_api_keys", return_value=["new-key", "old-key"]), \
+         patch("handler.process_page", return_value={"id": "t", "markdown": "", "confidence": 1.0}):
+
+        event = {
+            "headers": {"x-api-key": "new-key"},
+            "requestContext": {"http": {"method": "POST"}},
+            "body": json.dumps({"pages": [{"id": "t", "data": base64.b64encode(b"x").decode()}]}),
+        }
+        result = handler(event, None)
+        assert result["statusCode"] == 200
+
+
 def test_wrong_method():
     """Non-POST request returns 405."""
-    with patch("handler.get_api_key", return_value="test-key"):
+    with patch("handler.get_api_keys", return_value=["test-key"]):
         event = {
             "headers": {"x-api-key": "test-key"},
             "requestContext": {"http": {"method": "GET"}},
@@ -62,7 +90,7 @@ def test_wrong_method():
 
 def test_no_pages():
     """Request with no pages returns 400."""
-    with patch("handler.get_api_key", return_value="test-key"):
+    with patch("handler.get_api_keys", return_value=["test-key"]):
         event = {
             "headers": {"x-api-key": "test-key"},
             "requestContext": {"http": {"method": "POST"}},
@@ -74,7 +102,7 @@ def test_no_pages():
 
 def test_valid_request_structure():
     """Valid request returns proper response structure."""
-    with patch("handler.get_api_key", return_value="test-key"), \
+    with patch("handler.get_api_keys", return_value=["test-key"]), \
          patch("handler.process_page", return_value={"id": "test", "markdown": "Hello", "confidence": 0.95}):
 
         event = {
@@ -93,7 +121,7 @@ def test_valid_request_structure():
 
 def test_base64_encoded_body():
     """Handler decodes base64-encoded body."""
-    with patch("handler.get_api_key", return_value="test-key"), \
+    with patch("handler.get_api_keys", return_value=["test-key"]), \
          patch("handler.process_page", return_value={"id": "test", "markdown": "Hello", "confidence": 0.95}):
 
         body = json.dumps({
@@ -113,7 +141,7 @@ def test_base64_encoded_body():
 
 def test_invalid_json_body():
     """Invalid JSON returns 400 with parse error."""
-    with patch("handler.get_api_key", return_value="test-key"):
+    with patch("handler.get_api_keys", return_value=["test-key"]):
         event = {
             "headers": {"x-api-key": "test-key"},
             "requestContext": {"http": {"method": "POST"}},
@@ -127,7 +155,7 @@ def test_invalid_json_body():
 
 def test_too_many_pages():
     """Request with too many pages returns 400."""
-    with patch("handler.get_api_key", return_value="test-key"):
+    with patch("handler.get_api_keys", return_value=["test-key"]):
         # Create 21 pages (exceeds MAX_PAGES=20)
         pages = [{"id": f"page-{i}", "data": "dGVzdA=="} for i in range(21)]
         event = {
@@ -143,7 +171,7 @@ def test_too_many_pages():
 
 def test_page_exceeds_size_limit():
     """Oversized page is added to failedPages."""
-    with patch("handler.get_api_key", return_value="test-key"), \
+    with patch("handler.get_api_keys", return_value=["test-key"]), \
          patch("handler.MAX_PAGE_SIZE", 10):  # Set tiny limit for test
 
         # Create page larger than limit
@@ -161,7 +189,7 @@ def test_page_exceeds_size_limit():
 
 def test_empty_page_data():
     """Page with empty data is added to failedPages."""
-    with patch("handler.get_api_key", return_value="test-key"):
+    with patch("handler.get_api_keys", return_value=["test-key"]):
         event = {
             "headers": {"x-api-key": "test-key"},
             "requestContext": {"http": {"method": "POST"}},
@@ -175,7 +203,7 @@ def test_empty_page_data():
 
 def test_missing_anthropic_key_for_handwriting():
     """Missing Anthropic key for handwriting returns specific error."""
-    with patch("handler.get_api_key", return_value="test-key"), \
+    with patch("handler.get_api_keys", return_value=["test-key"]), \
          patch("handler.extract_typed_text", return_value=None), \
          patch("handler.has_strokes", return_value=True):
 
@@ -195,7 +223,7 @@ def test_missing_anthropic_key_for_handwriting():
 
 def test_process_page_exception_adds_to_failed():
     """Generic exception in process_page adds to failedPages."""
-    with patch("handler.get_api_key", return_value="test-key"), \
+    with patch("handler.get_api_keys", return_value=["test-key"]), \
          patch("handler.process_page", side_effect=Exception("Unexpected error")):
 
         event = {

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -50,9 +50,10 @@ def test_invalid_api_key():
 
 
 def test_grace_period_key_accepted():
-    """During rotation, old (grace-period) key is still accepted."""
+    """During rotation, old (grace-period) key is still accepted and logged."""
     with patch("handler.get_api_keys", return_value=["new-key", "old-key"]), \
-         patch("handler.process_page", return_value={"id": "t", "markdown": "", "confidence": 1.0}):
+         patch("handler.process_page", return_value={"id": "t", "markdown": "", "confidence": 1.0}), \
+         patch("handler.logger") as mock_logger:
 
         event = {
             "headers": {"x-api-key": "old-key"},
@@ -61,6 +62,7 @@ def test_grace_period_key_accepted():
         }
         result = handler(event, None)
         assert result["statusCode"] == 200
+        mock_logger.info.assert_any_call("Authenticated with grace-period key (rotation pending)")
 
 
 def test_primary_key_accepted_during_rotation():

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,167 @@
+"""Tests for secrets module — JSON parsing, TTL caching, and env var fallback."""
+
+import json
+import sys
+import time
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, "src")
+
+import secrets as secrets_module
+from secrets import get_api_keys, CACHE_TTL_SECONDS
+
+
+def _reset_cache():
+    """Reset module-level cache state between tests."""
+    secrets_module._cached_keys = None
+    secrets_module._cache_time = 0
+
+
+# --- Environment variable fallback ---
+
+
+def test_env_var_override():
+    """API_KEY env var returns single-element list."""
+    _reset_cache()
+    with patch.dict("os.environ", {"API_KEY": "env-test-key"}):
+        result = get_api_keys()
+        assert result == ["env-test-key"]
+
+
+def test_env_var_skips_secrets_manager():
+    """API_KEY env var bypasses Secrets Manager entirely."""
+    _reset_cache()
+    with patch.dict("os.environ", {"API_KEY": "local-key"}), \
+         patch.object(secrets_module, "get_secrets_client") as mock_client:
+        get_api_keys()
+        mock_client.assert_not_called()
+
+
+# --- JSON array parsing ---
+
+
+def test_json_array_secret():
+    """JSON array secret returns list of keys in order."""
+    _reset_cache()
+    mock_client = MagicMock()
+    mock_client.get_secret_value.return_value = {
+        "SecretString": json.dumps(["new-key", "old-key"])
+    }
+    with patch.dict("os.environ", {"API_KEY_SECRET_ARN": "arn:test"}, clear=False), \
+         patch.object(secrets_module, "get_secrets_client", return_value=mock_client), \
+         patch.dict("os.environ", {}, clear=False):
+        # Remove API_KEY if set
+        with patch.dict("os.environ", {"API_KEY_SECRET_ARN": "arn:test"}):
+            import os
+            os.environ.pop("API_KEY", None)
+            result = get_api_keys()
+            assert result == ["new-key", "old-key"]
+
+
+def test_plain_string_secret():
+    """Plain string secret returns single-element list."""
+    _reset_cache()
+    mock_client = MagicMock()
+    mock_client.get_secret_value.return_value = {
+        "SecretString": "plain-api-key-no-json"
+    }
+    import os
+    os.environ.pop("API_KEY", None)
+    with patch.dict("os.environ", {"API_KEY_SECRET_ARN": "arn:test"}), \
+         patch.object(secrets_module, "get_secrets_client", return_value=mock_client):
+        result = get_api_keys()
+        assert result == ["plain-api-key-no-json"]
+
+
+def test_json_encoded_string_secret():
+    """JSON-encoded string (not array) uses parsed value, not raw JSON."""
+    _reset_cache()
+    mock_client = MagicMock()
+    # A JSON string like '"my-key"' — json.loads returns 'my-key' (without quotes)
+    mock_client.get_secret_value.return_value = {
+        "SecretString": '"my-key"'
+    }
+    import os
+    os.environ.pop("API_KEY", None)
+    with patch.dict("os.environ", {"API_KEY_SECRET_ARN": "arn:test"}), \
+         patch.object(secrets_module, "get_secrets_client", return_value=mock_client):
+        result = get_api_keys()
+        assert result == ["my-key"]  # parsed, not ['"my-key"']
+
+
+# --- TTL caching ---
+
+
+def test_cache_returns_without_fetch():
+    """Cached keys are returned without calling Secrets Manager."""
+    _reset_cache()
+    mock_client = MagicMock()
+    mock_client.get_secret_value.return_value = {
+        "SecretString": json.dumps(["cached-key"])
+    }
+    import os
+    os.environ.pop("API_KEY", None)
+    with patch.dict("os.environ", {"API_KEY_SECRET_ARN": "arn:test"}), \
+         patch.object(secrets_module, "get_secrets_client", return_value=mock_client):
+        # First call fetches
+        get_api_keys()
+        # Second call should use cache
+        get_api_keys()
+        assert mock_client.get_secret_value.call_count == 1
+
+
+def test_cache_expires_after_ttl():
+    """Cache expires after TTL and re-fetches from Secrets Manager."""
+    _reset_cache()
+    mock_client = MagicMock()
+    mock_client.get_secret_value.return_value = {
+        "SecretString": json.dumps(["key-v1"])
+    }
+    import os
+    os.environ.pop("API_KEY", None)
+    with patch.dict("os.environ", {"API_KEY_SECRET_ARN": "arn:test"}), \
+         patch.object(secrets_module, "get_secrets_client", return_value=mock_client):
+        get_api_keys()
+
+        # Simulate TTL expiry
+        secrets_module._cache_time = time.monotonic() - CACHE_TTL_SECONDS - 1
+
+        mock_client.get_secret_value.return_value = {
+            "SecretString": json.dumps(["key-v2"])
+        }
+        result = get_api_keys()
+        assert result == ["key-v2"]
+        assert mock_client.get_secret_value.call_count == 2
+
+
+def test_empty_list_is_cached():
+    """Empty list from Secrets Manager is still cached (no repeated fetches)."""
+    _reset_cache()
+    mock_client = MagicMock()
+    mock_client.get_secret_value.return_value = {
+        "SecretString": json.dumps([])
+    }
+    import os
+    os.environ.pop("API_KEY", None)
+    with patch.dict("os.environ", {"API_KEY_SECRET_ARN": "arn:test"}), \
+         patch.object(secrets_module, "get_secrets_client", return_value=mock_client):
+        get_api_keys()
+        get_api_keys()
+        assert mock_client.get_secret_value.call_count == 1
+
+
+# --- Error cases ---
+
+
+def test_missing_secret_arn_raises():
+    """Missing API_KEY_SECRET_ARN raises ValueError."""
+    _reset_cache()
+    import os
+    os.environ.pop("API_KEY", None)
+    os.environ.pop("API_KEY_SECRET_ARN", None)
+    with patch.dict("os.environ", {}, clear=False):
+        try:
+            get_api_keys()
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "API_KEY_SECRET_ARN" in str(e)


### PR DESCRIPTION
## Summary

- Replace `lru_cache` (caches forever) with TTL-based caching (5 min) in `secrets.py` so key rotation takes effect without redeployment
- Support JSON array secret format `["new-key", "old-key"]` for dual-key grace periods — both keys valid during rotation window
- Auth in `handler.py` checks all valid keys, logs when grace-period key is used (rotation observability)
- Add `scripts/rotate-key.sh` — two-phase rotation script (`rotate` → update Prose → `--finalize`)

## Rotation flow

```
./scripts/rotate-key.sh              # add new key, keep old valid
# → copy new key to Prose config, verify it works
./scripts/rotate-key.sh --finalize   # remove old key (with confirmation)
```

## Test plan

- [x] All 58 existing tests pass
- [x] New test: grace-period (old) key accepted during rotation
- [x] New test: primary (new) key accepted during rotation
- [ ] Manual: run rotation script against staging secret
- [ ] Manual: verify Prose works with new key before finalizing

Refs solo-ist/prose#299

🤖 Generated with [Claude Code](https://claude.com/claude-code)