### PR TITLE
fix(renderer): expand canvas to fit infinite-scroll strokes

### DIFF
--- a/src/rm_renderer.py
+++ b/src/rm_renderer.py
@@ -22,6 +22,14 @@ X_OFFSET = RM_WIDTH / 2  # 702
 # typical pages while remaining readable for Claude Vision OCR.
 RENDER_SCALE = 0.5
 
+# Cap on rendered canvas height in native pixels. ~6× standard page height,
+# which covers the longest "infinite scroll" pages observed while keeping the
+# largest dimension under Claude Vision's 8000² ceiling at scale=0.5.
+MAX_CANVAS_HEIGHT = 12000
+
+# Bottom/right padding around stroke extents so glyphs don't touch the edge.
+PADDING_PX = 20
+
 # Brush colors (reMarkable uses 0=black, 1=gray, 2=white). Color names and
 # hex strings are accepted by PIL ImageDraw in both "RGB" and "L" modes.
 BRUSH_COLORS = {
@@ -29,6 +37,50 @@ BRUSH_COLORS = {
     1: "#808080",  # gray
     2: "white",
 }
+
+
+def _iter_lines(blocks):
+    """Yield Line objects from rmscene blocks (v6 format + legacy fallback)."""
+    for block in blocks:
+        if hasattr(block, "item") and block.item is not None:
+            item = block.item
+            if hasattr(item, "value") and item.value is not None:
+                line = item.value
+                if hasattr(line, "points"):
+                    yield line
+                    continue
+        if hasattr(block, "value") and hasattr(block.value, "points"):
+            yield block.value
+
+
+def _compute_canvas_dims(blocks, scale):
+    """Walk strokes once to derive a canvas that fits every point.
+
+    Returns (width, height, x_offset_native) where width/height are the scaled
+    output pixel dimensions and x_offset_native is the un-scaled X shift
+    applied to each point so that center-origin reMarkable coords land inside
+    the canvas. Floors at standard page dims so empty/short pages still render
+    at the familiar size; ceilings at MAX_CANVAS_HEIGHT to bound payload.
+    """
+    max_y_strokes = 0
+    max_x_extent = X_OFFSET  # half-width from center (RM_WIDTH / 2)
+    for line in _iter_lines(blocks):
+        for p in line.points:
+            if p.y > max_y_strokes:
+                max_y_strokes = p.y
+            ax = abs(p.x)
+            if ax > max_x_extent:
+                max_x_extent = ax
+    # Only pad past the standard page when strokes actually overflow it —
+    # short/empty pages keep their familiar RM_HEIGHT so existing call sites
+    # and the Prose UI see no dimension change for typical content.
+    if max_y_strokes > RM_HEIGHT:
+        max_y = min(max_y_strokes + PADDING_PX, MAX_CANVAS_HEIGHT)
+    else:
+        max_y = RM_HEIGHT
+    width = max(1, int(max(RM_WIDTH, 2 * max_x_extent) * scale))
+    height = max(1, int(max_y * scale))
+    return width, height, max_x_extent
 
 
 def extract_typed_text(rm_bytes: bytes) -> str | None:
@@ -72,10 +124,12 @@ def render_rm_to_png(rm_bytes: bytes, scale: float = RENDER_SCALE) -> bytes:
     # Parse .rm file
     blocks = list(read_blocks(BytesIO(rm_bytes)))
 
-    # Compute scaled output dimensions and offset.
-    out_w = max(1, int(RM_WIDTH * scale))
-    out_h = max(1, int(RM_HEIGHT * scale))
-    x_offset_scaled = X_OFFSET * scale
+    # Size the canvas to the strokes' actual extent so infinite-scroll pages
+    # aren't truncated. x_offset_native is the un-scaled X shift; using
+    # max(X_OFFSET, ...) keeps the center-origin transform valid even when a
+    # stroke pushes past the standard half-width.
+    out_w, out_h, x_offset_native = _compute_canvas_dims(blocks, scale)
+    x_offset_effective = max(X_OFFSET, x_offset_native)
 
     # Grayscale ("L") mode is one byte per pixel vs three for "RGB" — direct
     # 3x payload reduction. Strokes are monochrome on white so no color is lost.
@@ -83,28 +137,13 @@ def render_rm_to_png(rm_bytes: bytes, scale: float = RENDER_SCALE) -> bytes:
     draw = ImageDraw.Draw(img)
 
     # Draw each stroke
-    for block in blocks:
-        line = None
-
-        # rmscene v6 format: SceneLineItemBlock → item.value → Line
-        if hasattr(block, "item") and block.item is not None:
-            item = block.item
-            if hasattr(item, "value") and item.value is not None:
-                line = item.value
-
-        # Fallback: direct line attribute
-        elif hasattr(block, "value") and hasattr(block.value, "points"):
-            line = block.value
-
-        if line is None or not hasattr(line, "points"):
-            continue
-
+    for line in _iter_lines(blocks):
         if len(line.points) < 2:
             continue
 
         # Extract points: apply X offset for center-origin coordinate system,
         # then scale into output canvas.
-        points = [((p.x + X_OFFSET) * scale, p.y * scale) for p in line.points]
+        points = [((p.x + x_offset_effective) * scale, p.y * scale) for p in line.points]
 
         # Determine stroke color
         color_idx = getattr(line, "color", 0)
@@ -136,17 +175,6 @@ def has_strokes(rm_bytes: bytes) -> bool:
     """
     try:
         blocks = list(read_blocks(BytesIO(rm_bytes)))
-        for block in blocks:
-            # rmscene v6 format: SceneLineItemBlock → item.value → Line
-            if hasattr(block, "item") and block.item is not None:
-                item = block.item
-                if hasattr(item, "value") and item.value is not None:
-                    if hasattr(item.value, "points") and len(item.value.points) > 0:
-                        return True
-            # Fallback
-            if hasattr(block, "value") and hasattr(block.value, "points"):
-                if len(block.value.points) > 0:
-                    return True
-        return False
+        return any(len(line.points) > 0 for line in _iter_lines(blocks))
     except Exception:
         return False

--- a/tests/test_ocr_accuracy.py
+++ b/tests/test_ocr_accuracy.py
@@ -35,11 +35,11 @@ SAMPLE_RM = FIXTURE_DIR / "sample.rm"
 SAMPLE_EXPECTED = FIXTURE_DIR / "sample.txt"
 
 # Fraction of expected tokens that must appear in OCR output for the test
-# to pass. 0.7 is a deliberate floor — Claude Vision is not perfect on
-# cursive, and we'd rather catch *catastrophic* regressions (PNG resize
-# breaks coordinates, prompt change collapses output) than false-positive on
-# normal OCR variance.
-ACCURACY_THRESHOLD = 0.7
+# to pass. 0.95 is tight on purpose: with the bbox-driven canvas (issue #14)
+# the renderer no longer silently clips strokes, so missing >5% of distinct
+# tokens is a structural-regression signal rather than OCR variance noise.
+# Was 0.7 historically, which masked the truncation bug at 11/12 = 91.7%.
+ACCURACY_THRESHOLD = 0.95
 
 
 @pytest.fixture

--- a/tests/test_rm_renderer.py
+++ b/tests/test_rm_renderer.py
@@ -14,11 +14,34 @@ from rm_renderer import (
     RM_WIDTH,
     RM_HEIGHT,
     RENDER_SCALE,
+    MAX_CANVAS_HEIGHT,
+    PADDING_PX,
     BRUSH_COLORS,
     extract_typed_text,
     render_rm_to_png,
     has_strokes,
 )
+
+
+def _mock_block_with_stroke(points):
+    """Build a v6-format mock block whose line has the given (x, y) points."""
+    mock_points = []
+    for x, y in points:
+        p = MagicMock()
+        p.x = x
+        p.y = y
+        mock_points.append(p)
+
+    mock_line = MagicMock()
+    mock_line.points = mock_points
+    mock_line.color = 0
+    mock_line.thickness_scale = 2
+
+    mock_item = MagicMock()
+    mock_item.value = mock_line
+    mock_block = MagicMock()
+    mock_block.item = mock_item
+    return mock_block
 
 
 def test_constants():
@@ -383,3 +406,53 @@ def test_has_strokes_v6_format():
 
     with patch("rm_renderer.read_blocks", return_value=[mock_block]):
         assert has_strokes(b"fake rm data") is True
+
+
+def test_canvas_expands_for_infinite_scroll_strokes():
+    """Strokes past RM_HEIGHT extend the canvas instead of getting clipped."""
+    from PIL import Image
+    from io import BytesIO as _BytesIO
+
+    # y=2500 is well past RM_HEIGHT (1872) — the stroke would be silently
+    # dropped if the canvas were still hardcoded to RM_HEIGHT.
+    block = _mock_block_with_stroke([(0, 2400), (100, 2500)])
+
+    with patch("rm_renderer.read_blocks", return_value=[block]):
+        png_bytes = render_rm_to_png(b"fake rm data")
+
+    img = Image.open(_BytesIO(png_bytes))
+    # Expected: (max_y_strokes + PADDING_PX) * RENDER_SCALE = (2500 + 20) * 0.5 = 1260
+    assert img.size[1] == int((2500 + PADDING_PX) * RENDER_SCALE)
+    # And it must be strictly larger than the old hardcoded height.
+    assert img.size[1] > int(RM_HEIGHT * RENDER_SCALE)
+
+
+def test_canvas_floors_at_rm_height_for_short_pages():
+    """Strokes confined to standard page bounds preserve standard canvas dims."""
+    from PIL import Image
+    from io import BytesIO as _BytesIO
+
+    # Stroke entirely within the visible page — no expansion needed.
+    block = _mock_block_with_stroke([(0, 100), (100, 500)])
+
+    with patch("rm_renderer.read_blocks", return_value=[block]):
+        png_bytes = render_rm_to_png(b"fake rm data")
+
+    img = Image.open(_BytesIO(png_bytes))
+    assert img.size == (int(RM_WIDTH * RENDER_SCALE), int(RM_HEIGHT * RENDER_SCALE))
+
+
+def test_canvas_caps_at_max_canvas_height():
+    """Pathologically tall strokes are bounded by MAX_CANVAS_HEIGHT."""
+    from PIL import Image
+    from io import BytesIO as _BytesIO
+
+    # y=20000 well exceeds MAX_CANVAS_HEIGHT (12000) — without the cap,
+    # canvas would balloon past Claude Vision's 8000² limit.
+    block = _mock_block_with_stroke([(0, 19000), (100, 20000)])
+
+    with patch("rm_renderer.read_blocks", return_value=[block]):
+        png_bytes = render_rm_to_png(b"fake rm data")
+
+    img = Image.open(_BytesIO(png_bytes))
+    assert img.size[1] == int(MAX_CANVAS_HEIGHT * RENDER_SCALE)


### PR DESCRIPTION
## Summary

- Replace the hardcoded `RM_WIDTH × RM_HEIGHT` canvas with a stroke-bbox-driven sizing pass. Floors at standard page dims so empty/short pages are unchanged; ceilings at `MAX_CANVAS_HEIGHT = 12000` to bound payload under Claude Vision's 8000² limit.
- Factor out `_iter_lines` so `render_rm_to_png`, `_compute_canvas_dims`, and `has_strokes` share one rmscene-traversal pattern (previously duplicated 3 ways).
- Bump `ACCURACY_THRESHOLD` 0.7 → 0.95 in the live OCR test. The lenient floor masked this exact bug: 11/12 = 91.7% cleared the threshold even though the 12th token was clipped.
- Add `test_canvas_expands_for_infinite_scroll_strokes`, `test_canvas_floors_at_rm_height_for_short_pages`, `test_canvas_caps_at_max_canvas_height` for falsifiable proof.

Empirical confirmation against `tests/fixtures/sample.rm`: rendered height grows 936 → 996 px, capturing the y=1931–1974 stroke cluster that was being silently dropped in production (also visible in Prose's `pageOCRCache` for this notebook).

Out of scope: reMarkable Paper Pro device variance (1620×2160 native, custom canvas centers) — bbox handles wider strokes via `max(RM_WIDTH, 2 * max_x_extent)`, but inferring intended center needs a Paper Pro fixture. Filed separately.

## Test plan

- [x] `pytest tests/test_rm_renderer.py -v` — 21/21 pass (18 existing + 3 new)
- [x] `pytest tests/test_handler.py tests/test_process_page.py tests/test_claude_client.py tests/test_markdown_formatter.py tests/test_secrets.py` — 56/56 pass
- [x] One-off render of `sample.rm` confirms canvas height grew 936 → 996 px
- [ ] Reviewer with `ANTHROPIC_API_KEY`: `pytest tests/test_ocr_accuracy.py -v -s` should now hit 12/12 tokens (previously 11/12) and clear the new 0.95 threshold at both default and full scale

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)